### PR TITLE
metal: 1-bit qmv_fast use 1 pack/thread for occupancy (~9% on M5)

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -852,7 +852,7 @@ METAL_FUNC void qmv_fast_impl(
     uint3 tid [[threadgroup_position_in_grid]],
     uint simd_gid [[simdgroup_index_in_threadgroup]],
     uint simd_lid [[thread_index_in_simdgroup]]) {
-  constexpr int packs_per_thread = bits == 2 ? 1 : 2;
+  constexpr int packs_per_thread = bits <= 2 ? 1 : 2;  // 1-bit: 1 pack (vpt=32) for occupancy
   constexpr int num_simdgroups = 2;
   constexpr int results_per_simdgroup = 4;
   constexpr int pack_factor = get_pack_factor<bits, 32>();


### PR DESCRIPTION
## What

`affine_qmv_fast` (the decode/token-gen quantized matvec) sets
`packs_per_thread = bits == 2 ? 1 : 2`, so **1-bit** falls into the `: 2` case and gets
`values_per_thread = pack_factor * 2 = 64` → `x_thread[64]` (~256 B/thread). That register
footprint drops occupancy, so 1-bit decode can't hide DRAM latency and **under-saturates
bandwidth (~75% on M5 Pro)** while 2-bit/4-bit saturate (~90/96%).

Use **1 pack/thread for `bits <= 2`** so 1-bit matches 2-bit's `values_per_thread = 32`
footprint. (2-bit already used 1 pack, so it is unchanged — it serves as a control below.)

## Why it helps

- **Occupancy:** halves per-thread register/`x_thread` pressure for 1-bit → better latency hiding.
- **Bonus correctness/robustness:** `scale_step_per_thread = group_size / values_per_thread` was
  `0` for `group_size = 32` at 1-bit (vpt=64); with vpt=32 it is well-defined for g32.

## Measured (Apple M5 Pro, distinct-weight DRAM-bound matvec, best-of-10)

2-bit is the drift control (untouched by this change):

| | before (packs=2) | after (packs=1) | Δ |
|---|---|---|---|
| **1-bit** | 24.0 µs/matvec | **21.9 µs/matvec** | **~9% faster** (75%→82% BW) |
| 2-bit (control) | 33.2 µs | 32.9 µs | 0.8% (drift) |

Correct: `quantized_matmul` vs dequantize+matmul rel_err **2.7e-4**. The control moving only 0.8%
confirms the 1-bit gain is real, not machine noise.

## Notes

- Measured on a contended M5 (shared with another profiling session) — the ~9% is robust vs the
  control, but a quiet machine would tighten the headline number.
- Remaining 1-bit under-saturation (82%→~95%) is dominated by scale+bias traffic (~33% of 1-bit
  bytes at group 64) — a follow-up (int8/shared scales), not this PR.
