### PR TITLE
metal: gate nax off for gen-17 devices (wrong gemm/qmm results on M5-class)

### DIFF
--- a/mlx/backend/metal/device.cpp
+++ b/mlx/backend/metal/device.cpp
@@ -797,7 +797,14 @@ bool is_nax_available() {
     auto& d = metal::device(mlx::core::Device::gpu);
     auto arch = d.get_architecture().back();
     auto gen = d.get_architecture_gen();
-    can_use_nax &= gen >= (arch == 'p' ? 18 : 17);
+    // gen-17 desktop parts (M5-class, applegpu_g17*) take the nax path under
+    // the old `gen >= 17` gate but compute WRONG results in the nax steel-gemm
+    // and qmm_t kernels (measured 2026-07-05: fp16 GEMM max|err| ~4 vs fp32 for
+    // every shape routed to steel_gemm_fused_nax; quantized qmm_t ~400 abs err;
+    // non-nax fallback bit-matches stock mlx). Require gen >= 18 on every
+    // device class until the g17 path is fixed and correctness-gated.
+    (void)arch;
+    can_use_nax &= gen >= 18;
     return can_use_nax;
   };
   static bool is_nax_available_ = _check_nax();


### PR DESCRIPTION
## What

One-line gating fix (+comment): require `gen >= 18` on every device class before enabling the nax path. Previously non-phone parts enabled it at `gen >= 17`, which put M5-class GPUs (`applegpu_g17s`) on the nax kernels.

## Why

The nax steel-gemm and qmm_t kernels compute wrong results on g17 silicon (they are gen-18 targeted):
- Plain fp16 GEMM routed to `steel_gemm_fused_nax`: max|err| ~4 vs fp32 ground truth (values essentially uncorrelated), for every routed shape — both `nn` and `nt`, aligned and unaligned tiles.
- Quantized `qmm_t` similarly wrong (~400 abs err).
- The non-nax fallback bit-matches stock mlx everywhere tested.

Shapes that route to split-K or gemv were unaffected, which made this look shape/composition-dependent downstream: models ran mostly fine at decode (M=1) and corrupted at prefill, surfacing as output degeneration that was chased through converters, packing, schedulers, and recurrence code before landing here.

## Validation

- 5-line repro: `x[16,5120]fp16 @ W.T[5120,10240]` — pre-fix err 3.94, post-fix 0.000976 (== stock).
- 25-cell sweep M∈{1,8,16,32,64} × N∈{1024..12288}: all broken cells pre-fix are clean post-fix (fp16 rounding ~0.00098).
- Runtime workaround used while this lands: `MLX_METAL_GPU_ARCH=applegpu_g15` (or any pre-nax arch) — the env override path is unchanged by this fix.

## Notes

Gate-first fix: g17 hardware may well be able to run a corrected nax path, but that kernel work should land behind a correctness gate (repro above) rather than a device-class assumption. Until then g17 falls back to the standard steel path.