### PR TITLE
1-bit affine qmv: shared-decode select+FMA in half

### DIFF
--- a/mlx/backend/metal/kernels/quantized.h
+++ b/mlx/backend/metal/kernels/quantized.h
@@ -931,6 +931,165 @@ METAL_FUNC void qmv_fast_impl(
   }
 }
 
+// Shared-decode select+FMA 1-bit qmv (sel_f16): one threadgroup covers
+// num_vecs input rows, so each packed weight word is streamed and decoded
+// ONCE per row tile instead of once per row (the per-row qmv re-reads the
+// full weight matrix M times). Same thread layout as qmv_fast (2 simdgroups
+// x 4 output rows, per-lane 32 consecutive k per 1024-k block). The decode
+// is a half-precision select (w = bit ? scale + bias : bias) from the packed
+// uint32 weight word, shared by the num_vecs per-row accumulators; per-row
+// accumulation runs in half fma with an fp32 promotion once per 1024-k
+// block. The half staging is load-bearing, not a nicety: the same tile with
+// fp32 decode + fp32 accumulators is register-bound (lm_head M=3 measured
+// 7.0x the DRAM floor vs 2.08x for this form).
+//
+// Numerics note: per-row results are NOT bit-identical to qmv_fast, and are
+// looser than the fp32 dequantize-then-FMA form: half products accumulate
+// over 32 values between fp32 promotions (measured max|err| ~0.7 at K=5120
+// vs ~0.3 for the per-row path, against an fp32-dequant reference). Ship
+// decisions for this path gate on measured logit-KLD, not on this bound.
+template <typename T, int group_size, int bits, int num_vecs>
+METAL_FUNC void qmv_sel_f16_impl(
+    const device uint32_t* w,
+    const device T* scales,
+    const device T* biases,
+    const device T* x,
+    device T* y,
+    const constant int& in_vec_size,
+    const constant int& out_vec_size,
+    const constant int& M,
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int packs_per_thread = bits <= 2 ? 1 : 2;
+  constexpr int num_simdgroups = 2;
+  constexpr int results_per_simdgroup = 4;
+  constexpr int pack_factor = get_pack_factor<bits, 32>();
+  constexpr int bytes_per_pack = get_bytes_per_pack<bits, 32>();
+  constexpr int values_per_thread = pack_factor * packs_per_thread;
+  constexpr int block_size = values_per_thread * SIMD_SIZE;
+  constexpr int scale_step_per_thread = group_size / values_per_thread;
+
+  static_assert(bits == 1, "qmv_sel_f16 is a 1-bit-only kernel");
+
+  const device uint8_t* ws = (const device uint8_t*)w;
+
+  typedef float U;
+
+  // Half staging throughout the shared-decode core: activations are cast to
+  // half on load, decoded weights live as half, and the inner loop is a
+  // native half fma. fp32 appears only in the per-block promotion and the
+  // final simd reduction.
+  thread half x_thread[num_vecs][values_per_thread];
+  thread half w_dq[values_per_thread];
+  thread U result[results_per_simdgroup][num_vecs] = {{0}};
+
+  // Adjust positions
+  const int in_vec_size_w = in_vec_size * bytes_per_pack / pack_factor;
+  const int in_vec_size_g = in_vec_size / group_size;
+  const int out_row = tid.y * (num_simdgroups * results_per_simdgroup) +
+      simd_gid * results_per_simdgroup;
+  const int vec0 = tid.x * num_vecs;
+
+  ws += out_row * in_vec_size_w + simd_lid * packs_per_thread * bytes_per_pack;
+  scales += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+  biases += out_row * in_vec_size_g + simd_lid / scale_step_per_thread;
+
+  // Rows past M re-read row M-1 (guarded at the write).
+  const device T* xv[num_vecs];
+#pragma clang loop unroll(full)
+  for (int v = 0; v < num_vecs; v++) {
+    xv[v] = x + min(vec0 + v, M - 1) * in_vec_size +
+        simd_lid * values_per_thread;
+  }
+
+  const int aligned_end = (in_vec_size / block_size) * block_size;
+
+  for (int k = 0; k < aligned_end; k += block_size) {
+#pragma clang loop unroll(full)
+    for (int v = 0; v < num_vecs; v++) {
+      for (int i = 0; i < values_per_thread; i++) {
+        x_thread[v][i] = static_cast<half>(xv[v][i]);
+      }
+    }
+
+    for (int row = 0; row < results_per_simdgroup; row++) {
+      auto wl = (const device uint32_t*)(ws + row * in_vec_size_w);
+      const half lo = static_cast<half>(biases[row * in_vec_size_g]);
+      const half hi = static_cast<half>(scales[row * in_vec_size_g]) + lo;
+
+      // At 1 bit one packed word is the lane's whole 32-value chunk; decode
+      // it once in half, shared by all num_vecs rows.
+      uint32_t wword = wl[0];
+#pragma clang loop unroll(full)
+      for (int i = 0; i < values_per_thread; i++) {
+        w_dq[i] = select(lo, hi, bool(wword & (1u << i)));
+      }
+
+#pragma clang loop unroll(full)
+      for (int v = 0; v < num_vecs; v++) {
+        half hacc = 0;
+        for (int i = 0; i < values_per_thread; i++) {
+          hacc = fma(x_thread[v][i], w_dq[i], hacc);
+        }
+        result[row][v] += static_cast<U>(hacc);
+      }
+    }
+
+    ws += block_size * bytes_per_pack / pack_factor;
+    scales += block_size / group_size;
+    biases += block_size / group_size;
+#pragma clang loop unroll(full)
+    for (int v = 0; v < num_vecs; v++) {
+      xv[v] += block_size;
+    }
+  }
+
+  if (aligned_end < in_vec_size) {
+    bool in_bounds = (aligned_end + simd_lid * values_per_thread) < in_vec_size;
+    if (in_bounds) {
+#pragma clang loop unroll(full)
+      for (int v = 0; v < num_vecs; v++) {
+        for (int i = 0; i < values_per_thread; i++) {
+          x_thread[v][i] = static_cast<half>(xv[v][i]);
+        }
+      }
+
+      for (int row = 0; row < results_per_simdgroup; row++) {
+        auto wl = (const device uint32_t*)(ws + row * in_vec_size_w);
+        const half lo = static_cast<half>(biases[row * in_vec_size_g]);
+        const half hi = static_cast<half>(scales[row * in_vec_size_g]) + lo;
+
+        uint32_t wword = wl[0];
+#pragma clang loop unroll(full)
+        for (int i = 0; i < values_per_thread; i++) {
+          w_dq[i] = select(lo, hi, bool(wword & (1u << i)));
+        }
+
+#pragma clang loop unroll(full)
+        for (int v = 0; v < num_vecs; v++) {
+          half hacc = 0;
+          for (int i = 0; i < values_per_thread; i++) {
+            hacc = fma(x_thread[v][i], w_dq[i], hacc);
+          }
+          result[row][v] += static_cast<U>(hacc);
+        }
+      }
+    }
+  }
+
+  y += out_row;
+  for (int row = 0; row < results_per_simdgroup; row++) {
+#pragma clang loop unroll(full)
+    for (int v = 0; v < num_vecs; v++) {
+      U r = simd_sum(result[row][v]);
+      if (simd_lid == 0 && vec0 + v < M) {
+        y[(vec0 + v) * out_vec_size + row] = static_cast<T>(r);
+      }
+    }
+  }
+}
+
 template <typename T, int group_size, int bits>
 METAL_FUNC void qmv_impl(
     const device uint32_t* w,
@@ -1754,6 +1913,59 @@ template <typename T, int group_size, int bits, bool batched>
       y,
       in_vec_size,
       out_vec_size,
+      tid,
+      simd_gid,
+      simd_lid);
+}
+
+template <typename T, int group_size, int bits, int num_vecs, bool batched>
+[[kernel]] void affine_qmv_sel_f16(
+    const device uint32_t* w [[buffer(0)]],
+    const device T* scales [[buffer(1)]],
+    const device T* biases [[buffer(2)]],
+    const device T* x [[buffer(3)]],
+    device T* y [[buffer(4)]],
+    const constant int& in_vec_size [[buffer(5)]],
+    const constant int& out_vec_size [[buffer(6)]],
+    const constant int& M [[buffer(7)]],
+    const constant int& x_batch_ndims [[buffer(8)]],
+    const constant int* x_shape [[buffer(9)]],
+    const constant int64_t* x_strides [[buffer(10)]],
+    const constant int& w_batch_ndims [[buffer(11)]],
+    const constant int* w_shape [[buffer(12)]],
+    const constant int64_t* w_strides [[buffer(13)]],
+    const constant int64_t* s_strides [[buffer(14)]],
+    const constant int64_t* b_strides [[buffer(15)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  if (batched) {
+    adjust_matrix_offsets<T>(
+        x,
+        w,
+        scales,
+        biases,
+        y,
+        out_vec_size * M,
+        x_batch_ndims,
+        x_shape,
+        x_strides,
+        w_batch_ndims,
+        w_shape,
+        w_strides,
+        s_strides,
+        b_strides,
+        tid);
+  }
+  qmv_sel_f16_impl<T, group_size, bits, num_vecs>(
+      w,
+      scales,
+      biases,
+      x,
+      y,
+      in_vec_size,
+      out_vec_size,
+      M,
       tid,
       simd_gid,
       simd_lid);

--- a/mlx/backend/metal/kernels/quantized.metal
+++ b/mlx/backend/metal/kernels/quantized.metal
@@ -63,6 +63,16 @@
       k_lanes,                                                      \
       batched)
 
+#define instantiate_quantized_sel_f16(name, type, group_size, bits, vecs_per_tg, batched)     \
+  instantiate_kernel(                                                                          \
+      #name "_" #type "_gs_" #group_size "_b_" #bits "_nv_" #vecs_per_tg "_batch_" #batched,   \
+      name,                                                         \
+      type,                                                         \
+      group_size,                                                   \
+      bits,                                                         \
+      vecs_per_tg,                                                  \
+      batched)
+
 #define instantiate_quantized_split_k(name, type, group_size, bits, split_k)     \
   instantiate_kernel(                                                            \
       #name "_" #type "_gs_" #group_size "_b_" #bits "_spk_" #split_k, \
@@ -130,6 +140,17 @@
   instantiate_quantized_wide_wrap(affine_qmv_wide, type, group_size, bits, 4, 8) \
   instantiate_quantized_wide_wrap(affine_qmv_wide, type, group_size, bits, 5, 8)
 
+// sel_f16 (shared-decode select+FMA qmv) is only routed for 1-bit affine
+// (vecs_per_tg 2..4); other widths keep qmv_wide.
+#define instantiate_quantized_sel_f16_wrap(name, type, group_size, bits, vecs_per_tg) \
+  instantiate_quantized_sel_f16(name, type, group_size, bits, vecs_per_tg, 0)         \
+  instantiate_quantized_sel_f16(name, type, group_size, bits, vecs_per_tg, 1)
+
+#define instantiate_quantized_all_sel_f16_1bit(type, group_size) \
+  instantiate_quantized_sel_f16_wrap(affine_qmv_sel_f16, type, group_size, 1, 2) \
+  instantiate_quantized_sel_f16_wrap(affine_qmv_sel_f16, type, group_size, 1, 3) \
+  instantiate_quantized_sel_f16_wrap(affine_qmv_sel_f16, type, group_size, 1, 4)
+
 #define instantiate_quantized_all_splitk(type, group_size, bits)   \
   instantiate_quantized_split_k(affine_qvm_split_k, type, group_size, bits, 8)   \
   instantiate_quantized_split_k(affine_qvm_split_k, type, group_size, bits, 32)  \
@@ -180,4 +201,15 @@
   instantiate_quantized_groups(6) \
   instantiate_quantized_groups(8)
 
-instantiate_quantized_all() // clang-format on
+#define instantiate_quantized_sel_f16_types(group_size)            \
+  instantiate_quantized_all_sel_f16_1bit(float, group_size)        \
+  instantiate_quantized_all_sel_f16_1bit(float16_t, group_size)    \
+  instantiate_quantized_all_sel_f16_1bit(bfloat16_t, group_size)
+
+#define instantiate_quantized_sel_f16_all() \
+  instantiate_quantized_sel_f16_types(128)  \
+  instantiate_quantized_sel_f16_types(64)   \
+  instantiate_quantized_sel_f16_types(32)
+
+instantiate_quantized_all()
+instantiate_quantized_sel_f16_all() // clang-format on

--- a/mlx/backend/metal/quantized.cpp
+++ b/mlx/backend/metal/quantized.cpp
@@ -299,6 +299,7 @@ void qmv(
 // The 1-bit path has so little weight traffic that unpacking into registers
 // dominates even when several input rows reuse the result. The 2-bit path
 // breaks even after two rows and wins once three or more rows share a block.
+// (1-bit small-M is handled by qmv_sel_f16 before this is consulted.)
 inline bool
 use_qmv_wide(const std::string& mode, int bits, int M, metal::Device& d) {
   if (mode != "affine") {
@@ -308,6 +309,108 @@ use_qmv_wide(const std::string& mode, int bits, int M, metal::Device& d) {
     return false;
   }
   return d.get_architecture_gen() >= 15;
+}
+
+// True when the shared-decode sel_f16 qmv handles this matmul: 1-bit affine
+// with several input rows and qmv_fast-aligned shapes. It streams the weights
+// once per row tile (vs once per row), decoding each packed word ONCE in
+// half precision and sharing it across the tile's per-row half-fma
+// accumulators (fp32 promotion per 1024-k block). qmv_wide's generic
+// 8-value dequant->scalar-FMA decode is ALU-bound at 1 bit (measured worse
+// than M x per-row qmv), so 1-bit never routes there. M == 1 keeps the
+// per-row qmv path: sel_f16 is parity there and the M=1 decode hot path
+// must stay bit-identical.
+//
+// Restricted to half/bfloat activations: the half accumulation is a lossy
+// tradeoff (~2x the shipping path's quant error, gated downstream by
+// logit-KLD) that only makes sense where the caller already accepted
+// half-level precision. An fp32 caller keeps the precise per-row qmv, whose
+// fp32 accumulation is ~400x tighter and which is not a decode hot path.
+inline bool use_qmv_sel_f16(
+    const std::string& mode,
+    int bits,
+    int M,
+    int N,
+    int K,
+    Dtype dtype) {
+  return mode == "affine" && bits == 1 && M >= 2 && N % 8 == 0 &&
+      K % 512 == 0 && (dtype == float16 || dtype == bfloat16);
+}
+
+// Shared-decode sel_f16 qmv: vecs_per_tg input rows share each streamed and
+// half-decoded weight chunk. Grid mirrors qmv (2 simdgroups x 4 output rows
+// per threadgroup); tiles along M use the fewest tiles, then the smallest
+// tile that covers M.
+void qmv_sel_f16(
+    const array& x,
+    const array& w,
+    const array& scales,
+    const std::optional<array>& biases,
+    array& out,
+    int group_size,
+    int bits,
+    int M,
+    int N,
+    int K,
+    metal::Device& d,
+    const Stream& s,
+    const std::string& mode) {
+  // Register pressure (num_vecs x 32 half activations per lane at 1 bit)
+  // caps the tile at 4 rows.
+  constexpr int max_vecs_per_tg = 4;
+  int n_tiles = (M + max_vecs_per_tg - 1) / max_vecs_per_tg;
+  int vecs_per_tg = (M + n_tiles - 1) / n_tiles;
+
+  int B = out.size() / M / N;
+
+  int bn = 8;
+  int bk = 32;
+  MTL::Size group_dims(bk, 2, 1);
+  MTL::Size grid_dims(n_tiles, (N + bn - 1) / bn, B);
+
+  std::string kname;
+  kname.reserve(64);
+  std::string type_string = get_type_string(x.dtype());
+
+  concatenate(
+      kname,
+      mode + "_qmv_sel_f16_",
+      type_string,
+      "_gs_",
+      group_size,
+      "_b_",
+      bits,
+      "_nv_",
+      vecs_per_tg,
+      B > 1 ? "_batch_1" : "_batch_0");
+  auto kernel = get_quantized_kernel_wrapped(
+      d,
+      kname,
+      "qmv_sel_f16",
+      mode,
+      type_string,
+      group_size,
+      bits,
+      vecs_per_tg,
+      B > 1);
+
+  auto& compute_encoder = metal::get_command_encoder(s);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  int c = 0;
+  compute_encoder.set_input_array(w, c++);
+  compute_encoder.set_input_array(scales, c++);
+  if (biases) {
+    compute_encoder.set_input_array(*biases, c++);
+  }
+  compute_encoder.set_input_array(x, c++);
+  compute_encoder.set_output_array(out, c++);
+  compute_encoder.set_bytes(K, c++);
+  compute_encoder.set_bytes(N, c++);
+  compute_encoder.set_bytes(M, c++);
+  add_strides_and_shapes(compute_encoder, B <= 1, x, w, scales, biases, c);
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
 }
 
 // Dispatches qmv_wide (fp modes -> fp_qmv_wide, affine -> affine_qmv_wide):
@@ -1479,6 +1582,15 @@ void dispatch_qmv(
   // It is a qmv with a small inner dimension so route to qmv_quad kernel
   if ((K == 128 || (K == 64 && bits >= 2)) && is_power_of_2(bits)) {
     qmv_quad(x, w, scales, biases, out, group_size, bits, M, N, K, d, s, mode);
+    return;
+  }
+
+  // 1-bit small batch (2 <= M < vector_limit): share each streamed weight
+  // chunk across the M rows, decoded once in half (qmv_wide's generic decode
+  // is ALU-bound at 1 bit; per-row qmv re-reads the weights M times).
+  if (use_qmv_sel_f16(mode, bits, M, N, K, x.dtype())) {
+    qmv_sel_f16(
+        x, w, scales, biases, out, group_size, bits, M, N, K, d, s, mode);
     return;
   }
 


### PR DESCRIPTION
## What
Adds a shared-decode 1-bit affine qmv kernel (`affine_qmv_sel_f16`) and routes small-batch 1-bit affine `quantized_matmul` to it for half/bfloat activations at `2 <= M < vector_limit`.

## Why
At 1 bit the existing small-batch paths are a poor fit. Per-row qmv re-streams the full weight matrix once per input row, and the generic `qmv_wide` decode is ALU-bound at 1 bit (measured worse than M x per-row qmv). Small-M 1-bit matmuls, such as speculative-decode verify steps, pay this repeatedly.

## How
One threadgroup covers `num_vecs` (2..4) input rows with the `qmv_fast` thread layout (2 simdgroups x 4 output rows, per-lane 32 consecutive k per 1024-k block). Each lane's packed `uint32` weight word is decoded once per row tile in half (`w = bit ? scale + bias : bias`) and shared across the per-row accumulators; per-row FMA runs in half with an fp32 promotion per 1024-k block.

The half staging is load-bearing: the same tile with fp32 decode and fp32 accumulators is register-bound (measured `lm_head` M=3 at 7.0x the DRAM floor) and drops to ~2.08x in half.

Routing is guarded: `bits == 1`, affine, half/bfloat activations, `2 <= M < vector_limit`, `N % 8 == 0`, `K % 512 == 0`. `M == 1` and fp32 callers keep the existing per-row qmv (`M == 1` is bit-identical). bits 2/4 routing is unchanged.

## Numerics
The half accumulation is intentionally looser than the per-row path (measured `max|err|` ~0.73 vs ~0.31 at K=5120, ~2x relative vs an fp32-dequant reference, gs {32,64,128}). It is a throughput-for-precision trade for small-batch 1-bit decode; callers needing exact accumulation should keep `M == 1` or fp32, and gate any adoption on measured end-to-end logit-KLD.

## Validation
- Correctness sweep vs fp32-dequant reference across the hot matmul shapes, gs {32,64,128}, {f16,bf16,f32}, M 1..12, plus N/K-unaligned fallbacks (bit-identical to the old path) and bits 2/4 routing.
- `M == 1` bit-identical to the per-row qmv path.
- On-device micro and end-to-end A/B on Apple Silicon (M5 Pro): no regression at any M, faster small-batch verify, and a measured logit-KLD check against a same-path control (near-zero divergence).
