### PR TITLE
Backport generation-18 NAX guard to release core

### DIFF
--- a/mlx/backend/metal/device.h
+++ b/mlx/backend/metal/device.h
@@ -276,9 +276,9 @@ inline bool is_nax_available() {
       can_use_nax = true;
     }
     auto& d = metal::device(mlx::core::Device::gpu);
-    auto arch = d.get_architecture().back();
     auto gen = d.get_architecture_gen();
-    can_use_nax &= gen >= (arch == 'p' ? 18 : 17);
+    // Gen-17 NAX miscomputes wide GEMM and quantized matmul.
+    can_use_nax &= gen >= 18;
     return can_use_nax;
   };
   static bool is_nax_available_ = _check_nax();


### PR DESCRIPTION
## What

Backport the generation-18 NAX guard to the release core branch used by the Swift package.

## Why

The release source still permits generation-17 NAX dispatch while the Swift package's flattened header disables it. Different translation units therefore see different guards. A clean Swift checkout fails 20 strict Hadamard/quantized-matmul comparisons with the old core pin.

## How

Apply the existing fix from #4 to the release's inline `is_nax_available` implementation. Require generation 18 across device classes, preserving the official release ancestry with one focused commit.

## Test plan

Validate through the Swift package on M5 Pro with Xcode 26.6: Hadamard layer tests, 60 composed low-bit matmul cases, embedding/tied-projection and GDN checks, and existing quantization/NAX regressions. No performance or full-model quality claim.
